### PR TITLE
RefitInternalGenerated using declaration moved

### DIFF
--- a/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
+++ b/InterfaceStubGenerator.Core/GeneratedInterfaceStubTemplate.mustache
@@ -2,6 +2,7 @@
 using System;
 using System.Net.Http;
 using System.Collections.Generic;
+using {{RefitInternalNamespace}}RefitInternalGenerated;
 
 /* ******** Hey You! *********
  *
@@ -30,7 +31,6 @@ namespace {{RefitInternalNamespace}}RefitInternalGenerated
 {{#ClassList}}
 namespace {{Namespace}}
 {
-    using {{RefitInternalNamespace}}RefitInternalGenerated;
     {{#UsingList}}
     using {{Item}};
     {{/UsingList}}


### PR DESCRIPTION
I found moving the RefitInternalGenerated using declaration to the top allowed my 3.1 project to build without the errors found in bug #649